### PR TITLE
Add http client provider

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,9 +1,14 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes), provideClientHydration()]
+  providers: [
+    provideRouter(routes),
+    provideClientHydration(),
+    provideHttpClient()
+  ]
 };


### PR DESCRIPTION
## Summary
- import `provideHttpClient` in `app.config`
- register `provideHttpClient()` with application config providers

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593cbe37fc83218934d1c156d8cdc2