### PR TITLE
Rename cart service and update imports

### DIFF
--- a/src/app/components/cart-form/cart-form.component.html
+++ b/src/app/components/cart-form/cart-form.component.html
@@ -1,0 +1,6 @@
+<form (ngSubmit)="submit()">
+  <textarea rows="6" [(ngModel)]="itemsText" name="items"></textarea>
+  <button type="submit">Calcola</button>
+</form>
+
+<pre *ngIf="response">{{ response | json }}</pre>

--- a/src/app/components/cart-form/cart-form.spec.ts
+++ b/src/app/components/cart-form/cart-form.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CartFormComponent } from './cart-form';
+
+describe('CartFormComponent', () => {
+  let component: CartFormComponent;
+  let fixture: ComponentFixture<CartFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CartFormComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CartFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/cart-form/cart-form.ts
+++ b/src/app/components/cart-form/cart-form.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CartService, CartRequest, CartResponse } from '../../services/cart.service';
+
+@Component({
+  selector: 'app-cart-form',
+  templateUrl: './cart-form.component.html',
+})
+export class CartFormComponent {
+  itemsText = '';
+  response?: CartResponse;
+
+  constructor(private cartService: CartService) { }
+
+  submit() {
+    const request: CartRequest = {
+      items: this.itemsText.split('\n').filter(line => line.trim() !== ''),
+    };
+
+    this.cartService.getCartResponse(request).subscribe(res => {
+      this.response = res;
+    });
+  }
+}

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { environment } from '../../environments/environment';
+
+export interface CartRequest {
+  items: string[];
+}
+
+export interface CartResponse {
+  items: string[];
+  salesTaxes: number;
+  total: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CartService {
+  constructor(private http: HttpClient) { }
+
+  getCartResponse(request: CartRequest) {
+    return this.http.post<CartResponse>(
+      `${environment.apiUrl}/GetCartResponse`,
+      request
+    );
+  }
+}

--- a/src/app/services/cart.spec.ts
+++ b/src/app/services/cart.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CartService } from './cart.service';
+
+describe('CartService', () => {
+  let service: CartService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CartService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: 'https://localhost:5001'   // oppure la porta reale del backend
+};


### PR DESCRIPTION
## Summary
- add `cart.service.ts` and environment configuration
- update `cart.spec.ts` import path
- add CartForm component that uses the renamed service

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593cbb342c8321b950d4054be0ee31