### PR TITLE
Fix tests by providing HttpClient

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [provideHttpClient()]
     }).compileComponents();
   });
 


### PR DESCRIPTION
## Summary
- provide HttpClient in `app.component.spec.ts` for `CartFormComponent`

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: npm 403 due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68594643b1f08321959faa719b2ed06f