### PR TITLE
Improve cart error messages

### DIFF
--- a/src/app/components/cart-form/cart-form.component.html
+++ b/src/app/components/cart-form/cart-form.component.html
@@ -3,7 +3,9 @@
 </div>
 <button type="button" (click)="submit()">Invia</button>
 <div *ngIf="loading">Caricamento...</div>
-<div *ngIf="error" class="error">{{ error }}</div>
+<div *ngIf="error" class="error">
+  {{ error }}<span *ngIf="errorDetail"> - {{ errorDetail }}</span>
+</div>
 <div *ngIf="response">
   <h3>Risposta</h3>
   <pre>{{ response | json }}</pre>

--- a/src/app/components/cart-form/cart-form.component.spec.ts
+++ b/src/app/components/cart-form/cart-form.component.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { CartFormComponent } from './cart-form.component';
+import { CartService } from '../../services/cart.service';
+import { throwError } from 'rxjs';
+
+class MockCartService {
+  getCartResponse() {
+    return throwError(() => ({ message: 'bad request', status: 400 }));
+  }
+}
+
+describe('CartFormComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CartFormComponent],
+      providers: [{ provide: CartService, useClass: MockCartService }]
+    }).compileComponents();
+  });
+
+  it('should display error details when service fails', () => {
+    const fixture = TestBed.createComponent(CartFormComponent);
+    const component = fixture.componentInstance;
+    component.itemsControl.setValue('item');
+    fixture.detectChanges();
+
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+
+    const err = fixture.nativeElement.querySelector('.error');
+    expect(err.textContent).toContain('Errore nella richiesta');
+    expect(err.textContent).toContain('bad request');
+  });
+});

--- a/src/app/components/cart-form/cart-form.component.ts
+++ b/src/app/components/cart-form/cart-form.component.ts
@@ -15,6 +15,7 @@ export class CartFormComponent {
   response?: CartResponse;
   loading = false;
   error?: string;
+  errorDetail?: string;
 
   constructor(private cartService: CartService) {}
 
@@ -26,14 +27,16 @@ export class CartFormComponent {
       .filter((v) => v);
     this.loading = true;
     this.error = undefined;
+    this.errorDetail = undefined;
     this.response = undefined;
     this.cartService.getCartResponse(items).subscribe({
       next: (res) => {
         this.response = res;
         this.loading = false;
       },
-      error: () => {
+      error: (err) => {
         this.error = 'Errore nella richiesta';
+        this.errorDetail = err.message ?? `status: ${err.status}`;
         this.loading = false;
       }
     });


### PR DESCRIPTION
## Summary
- show detailed error info when cart service fails
- render the detailed error in the cart form
- add unit test for the new error handling

## Testing
- `npm test -- --no-watch --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859464475d883218fae8fb3f5e0b825