### PR TITLE
docs: add backend running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,33 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 
 Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
 
+## Backend service
+
+The application expects a backend API listening on `https://localhost:5001`. Start the server for your backend implementation so the Angular app can POST cart items and receive totals. A typical workflow when using the provided ASP.NET service is:
+
+1. Navigate to the backend project folder.
+2. Run `dotnet run`.
+3. Verify that `https://localhost:5001` responds in your browser or via `curl`.
+
+If your API runs on a different URL, update `src/environments/environment.ts` accordingly:
+
+```ts
+export const environment = {
+  production: false,
+  apiUrl: 'https://your-api-host'
+};
+```
+
+The same value is also defined in `environment.prod.ts` for production builds.
+
+You can test the backend with a request similar to the following:
+
+```bash
+curl -k -X POST https://localhost:5001/GetCartResponse \
+  -H "Content-Type: application/json" \
+  -d '{"items": ["1 book at 12.49", "1 music CD at 14.99"]}'
+```
+
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.


### PR DESCRIPTION
## Summary
- explain how to run the backend server on https://localhost:5001
- document how to change `environment.ts` if the API URL changes
- show example curl request to the backend

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594645b6e88321addeb5f4c0be2742