### PR TITLE
Handle plain text cart response

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Run `ng build` to build the project. The build artifacts will be stored in the `
 
 Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
 
+## API Response
+
+`CartService.getCartResponse` expects a plain text response from the backend.
+The service sends a POST request with the `Accept: text/plain` header and the
+API returns a simple string instead of JSON.
+
 ## Running end-to-end tests
 
 Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.

--- a/src/app/components/cart-form/cart-form.component.html
+++ b/src/app/components/cart-form/cart-form.component.html
@@ -6,7 +6,5 @@
 <div *ngIf="error" class="error">{{ error }}</div>
 <div *ngIf="response">
   <h3>Risposta</h3>
-  <pre>{{ response | json }}</pre>
-  <p>Sales Taxes: {{ response.salesTaxes }}</p>
-  <p>Total: {{ response.total }}</p>
+  <pre>{{ response }}</pre>
 </div>

--- a/src/app/components/cart-form/cart-form.component.ts
+++ b/src/app/components/cart-form/cart-form.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormControl } from '@angular/forms';
-import { CartService, CartResponse } from '../../services/cart.service';
+import { CartService } from '../../services/cart.service';
 
 @Component({
   selector: 'app-cart-form',
@@ -12,7 +12,7 @@ import { CartService, CartResponse } from '../../services/cart.service';
 })
 export class CartFormComponent {
   itemsControl = new FormControl('', { nonNullable: true });
-  response?: CartResponse;
+  response?: string;
   loading = false;
   error?: string;
 

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 
@@ -13,10 +13,12 @@ export interface CartResponse {
 export class CartService {
   constructor(private http: HttpClient) {}
 
-  getCartResponse(items: string[]): Observable<CartResponse> {
-    return this.http.post<CartResponse>(
+  getCartResponse(items: string[]): Observable<string> {
+    const headers = new HttpHeaders({ Accept: 'text/plain' });
+    return this.http.post<string>(
       `${environment.apiUrl}/GetCartResponse`,
-      { items }
+      { items },
+      { headers, responseType: 'text' as const }
     );
   }
 }


### PR DESCRIPTION
## Summary
- adjust cart service to expect text/plain
- display the raw text in CartFormComponent
- document new API response format

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6859464a446c83218e0e64b2cdc55eb9