### PR TITLE
Enhance error handling in cart form

### DIFF
--- a/src/app/components/cart-form/cart-form.component.ts
+++ b/src/app/components/cart-form/cart-form.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormControl } from '@angular/forms';
 import { CartService, CartResponse } from '../../services/cart.service';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-cart-form',
@@ -32,8 +33,10 @@ export class CartFormComponent {
         this.response = res;
         this.loading = false;
       },
-      error: () => {
-        this.error = 'Errore nella richiesta';
+      error: (error: HttpErrorResponse) => {
+        console.error('Cart request failed', error.message || error.status);
+        this.error =
+          error.error?.message ?? 'Errore nella richiesta. Riprova più tardi.';
         this.loading = false;
       }
     });

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 
 export interface CartResponse {
@@ -14,9 +15,12 @@ export class CartService {
   constructor(private http: HttpClient) {}
 
   getCartResponse(items: string[]): Observable<CartResponse> {
-    return this.http.post<CartResponse>(
-      `${environment.apiUrl}/GetCartResponse`,
-      { items }
-    );
+    return this.http
+      .post<CartResponse>(`${environment.apiUrl}/GetCartResponse`, { items })
+      .pipe(
+        catchError((error: HttpErrorResponse) =>
+          throwError(() => error.error ?? error)
+        )
+      );
   }
 }


### PR DESCRIPTION
## Summary
- capture error payload in CartService
- log HttpErrorResponse details in cart form component
- show server-provided error messages to users

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859464b64808321998b8524d8a062e1