### PR TITLE
Use withFetch in HTTP client

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,12 +1,12 @@
 import { TestBed } from '@angular/core/testing';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
-      providers: [provideHttpClient()]
+      providers: [provideHttpClient(withFetch())]
     }).compileComponents();
   });
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,10 +1,10 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes), provideClientHydration(), provideHttpClient()]
+  providers: [provideRouter(routes), provideClientHydration(), provideHttpClient(withFetch())]
 };


### PR DESCRIPTION
## Summary
- configure HTTP client with `withFetch` in app config
- update spec to match `withFetch`

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c00acef2083218e02aa279b943cff