### PR TITLE
Add Angular Material to cart form

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,6 +25,7 @@
               "src/assets"
             ],
             "styles": [
+              "node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
               "src/styles.css"
             ],
             "scripts": [],
@@ -89,6 +90,7 @@
               "src/assets"
             ],
             "styles": [
+              "node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
               "src/styles.css"
             ],
             "scripts": []

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@angular/platform-server": "^17.3.0",
     "@angular/router": "^17.3.0",
     "@angular/ssr": "^17.3.17",
+    "@angular/material": "^17.3.0",
+    "@angular/cdk": "^17.3.0",
     "express": "^4.18.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/src/app/components/cart-form/cart-form.component.html
+++ b/src/app/components/cart-form/cart-form.component.html
@@ -1,7 +1,7 @@
-<div>
-  <textarea [formControl]="itemsControl" rows="5" placeholder="Inserisci gli articoli, uno per riga"></textarea>
-</div>
-<button type="button" (click)="submit()">Invia</button>
+<mat-form-field appearance="fill">
+  <textarea matInput [formControl]="itemsControl" rows="5" placeholder="Inserisci gli articoli, uno per riga"></textarea>
+</mat-form-field>
+<button mat-raised-button type="button" (click)="submit()">Invia</button>
 <div *ngIf="loading">Caricamento...</div>
 <div *ngIf="error" class="error">
   {{ error }}<span *ngIf="errorDetail"> - {{ errorDetail }}</span>

--- a/src/app/components/cart-form/cart-form.component.ts
+++ b/src/app/components/cart-form/cart-form.component.ts
@@ -1,13 +1,15 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormControl } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
 import { CartService, CartResponse } from '../../services/cart.service';
 import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-cart-form',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, MatInputModule, MatButtonModule],
   templateUrl: './cart-form.component.html',
   styleUrl: './cart-form.component.css'
 })


### PR DESCRIPTION
## Summary
- install Angular Material dependencies (fails in this environment)
- use MatInputModule and MatButtonModule in CartForm
- update cart form template with Angular Material
- include Material theme in build config

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c027f6764832180ae73e9953b3311