### PR TITLE
Improve cart form UI

### DIFF
--- a/src/app/components/cart-form/cart-form.component.css
+++ b/src/app/components/cart-form/cart-form.component.css
@@ -1,3 +1,32 @@
 .error {
   color: red;
 }
+
+.cart-form-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 2rem;
+}
+
+.cart-form {
+  width: 70%;
+  max-width: 800px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.items-list {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.item-actions {
+  margin-left: auto;
+}
+
+.edit-input {
+  width: 100%;
+}

--- a/src/app/components/cart-form/cart-form.component.html
+++ b/src/app/components/cart-form/cart-form.component.html
@@ -1,7 +1,43 @@
-<mat-form-field appearance="fill">
-  <textarea matInput [formControl]="itemsControl" rows="5" placeholder="Inserisci gli articoli, uno per riga"></textarea>
-</mat-form-field>
-<button mat-raised-button type="button" (click)="submit()">Invia</button>
+<div class="cart-form-container">
+  <div class="cart-form">
+    <mat-form-field appearance="fill" class="full-width">
+      <input
+        matInput
+        [formControl]="lineControl"
+        (keyup.enter)="addItem()"
+        placeholder="Aggiungi articolo" />
+    </mat-form-field>
+
+    <mat-list class="items-list">
+      <mat-list-item *ngFor="let item of items; let i = index">
+        <ng-container *ngIf="editIndex !== i; else editField">
+          {{ item }}
+        </ng-container>
+        <ng-template #editField>
+          <input
+            matInput
+            class="edit-input"
+            [(ngModel)]="editValue"
+            (keyup.enter)="saveEdit(i)"
+            (blur)="saveEdit(i)" />
+        </ng-template>
+        <span class="item-actions">
+          <button mat-icon-button (click)="startEdit(i)" *ngIf="editIndex !== i">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button mat-icon-button (click)="saveEdit(i)" *ngIf="editIndex === i">
+            <mat-icon>check</mat-icon>
+          </button>
+          <button mat-icon-button color="warn" (click)="deleteItem(i)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </span>
+      </mat-list-item>
+    </mat-list>
+
+    <button mat-raised-button type="button" (click)="submit()">Invia</button>
+  </div>
+</div>
 <div *ngIf="loading">Caricamento...</div>
 <div *ngIf="error" class="error">
   {{ error }}<span *ngIf="errorDetail"> - {{ errorDetail }}</span>

--- a/src/app/components/cart-form/cart-form.component.ts
+++ b/src/app/components/cart-form/cart-form.component.ts
@@ -1,20 +1,34 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormControl } from '@angular/forms';
+import { ReactiveFormsModule, FormControl, FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
 import { CartService, CartResponse } from '../../services/cart.service';
 import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-cart-form',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, MatInputModule, MatButtonModule],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    FormsModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatListModule
+  ],
   templateUrl: './cart-form.component.html',
   styleUrl: './cart-form.component.css'
 })
 export class CartFormComponent {
   itemsControl = new FormControl('', { nonNullable: true });
+  lineControl = new FormControl('', { nonNullable: true });
+  items: string[] = [];
+  editIndex = -1;
+  editValue = '';
   response?: CartResponse;
   loading = false;
   error?: string;
@@ -22,12 +36,48 @@ export class CartFormComponent {
 
   constructor(private cartService: CartService) {}
 
+  addItem(): void {
+    const value = this.lineControl.value.trim();
+    if (!value) {
+      return;
+    }
+    this.items.push(value);
+    this.updateItemsControl();
+    this.lineControl.setValue('');
+  }
+
+  startEdit(index: number): void {
+    this.editIndex = index;
+    this.editValue = this.items[index];
+  }
+
+  saveEdit(index: number): void {
+    const value = this.editValue.trim();
+    if (value) {
+      this.items[index] = value;
+    }
+    this.editIndex = -1;
+    this.editValue = '';
+    this.updateItemsControl();
+  }
+
+  deleteItem(index: number): void {
+    this.items.splice(index, 1);
+    this.updateItemsControl();
+  }
+
+  private updateItemsControl(): void {
+    this.itemsControl.setValue(this.items.join('\n'));
+  }
+
   submit(): void {
-    const text = this.itemsControl.value;
-    const items = text
-      .split('\n')
-      .map((v) => v.trim())
-      .filter((v) => v);
+    let items = [...this.items];
+    if (items.length === 0) {
+      items = this.itemsControl.value
+        .split('\n')
+        .map((v) => v.trim())
+        .filter((v) => v);
+    }
     this.loading = true;
     this.error = undefined;
     this.errorDetail = undefined;


### PR DESCRIPTION
## Summary
- add field for single line items
- display items in a Material list with edit/delete buttons
- style cart form container to be centered and 70% width

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea92d836483218d382683beeb94ff