### PR TITLE
Refactor cart DTOs

### DIFF
--- a/src/app/components/cart-form/cart-form.component.spec.ts
+++ b/src/app/components/cart-form/cart-form.component.spec.ts
@@ -4,7 +4,7 @@ import { CartService } from '../../services/cart.service';
 import { throwError } from 'rxjs';
 
 class MockCartService {
-  getCartResponse() {
+  getCartResponse(_req?: unknown) {
     return throwError(() => ({ message: 'bad request', status: 400 }));
   }
 }

--- a/src/app/components/cart-form/cart-form.component.ts
+++ b/src/app/components/cart-form/cart-form.component.ts
@@ -5,7 +5,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
-import { CartService, CartResponse } from '../../services/cart.service';
+import { CartService } from '../../services/cart.service';
+import { CartResponse } from '../../entities/DTOs/cart/responses/cart-response.dto';
 import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
@@ -74,7 +75,7 @@ export class CartFormComponent {
     this.error = undefined;
     this.errorDetail = undefined;
     this.response = undefined;
-    this.cartService.getCartResponse(items).subscribe({
+    this.cartService.getCartResponse({ items }).subscribe({
       next: (res: CartResponse) => {
         this.response = res;
         this.loading = false;

--- a/src/app/entities/DTOs/cart/requests/cart-request.dto.ts
+++ b/src/app/entities/DTOs/cart/requests/cart-request.dto.ts
@@ -1,0 +1,3 @@
+export interface CartRequest {
+  items: string[];
+}

--- a/src/app/entities/DTOs/cart/responses/cart-response.dto.ts
+++ b/src/app/entities/DTOs/cart/responses/cart-response.dto.ts
@@ -1,0 +1,5 @@
+export interface CartResponse {
+  items: string[];
+  salesTaxes: number;
+  total: number;
+}

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -3,20 +3,16 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
-
-export interface CartResponse {
-  items: string[];
-  salesTaxes: number;
-  total: number;
-}
+import { CartRequest } from '../entities/DTOs/cart/requests/cart-request.dto';
+import { CartResponse } from '../entities/DTOs/cart/responses/cart-response.dto';
 
 @Injectable({ providedIn: 'root' })
 export class CartService {
   constructor(private http: HttpClient) {}
 
-  getCartResponse(items: string[]): Observable<CartResponse> {
+  getCartResponse(request: CartRequest): Observable<CartResponse> {
     return this.http
-      .post<CartResponse>(`${environment.apiUrl}/GetCartResponse`, { items })
+      .post<CartResponse>(`${environment.apiUrl}/GetCartResponse`, request)
       .pipe(
         catchError((error: HttpErrorResponse) =>
           throwError(() => error.error ?? error)


### PR DESCRIPTION
## Summary
- move `CartResponse` to `entities/DTOs/cart/responses`
- add `CartRequest` DTO and use it in `CartService`
- update `CartFormComponent` and tests to use the new DTOs

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f70af5550832189540dc01b204117