### PR TITLE
Add sidenav toggle and backend button tests

### DIFF
--- a/src/app/layout/toolbar/toolbar.component.html
+++ b/src/app/layout/toolbar/toolbar.component.html
@@ -1,5 +1,15 @@
-<mat-toolbar color="primary" class="toolbar">
-  <span class="spacer"></span>
-  <button mat-button (click)="selectBackend('local')" [disabled]="currentUrl === LOCAL_IIS">Localhost IIS</button>
-  <button mat-button (click)="selectBackend('aws')" [disabled]="currentUrl === AWS_URL">Remote sales.raphp.net</button>
-</mat-toolbar>
+<mat-sidenav-container>
+  <mat-sidenav #sidenav>
+    <app-sidenav></app-sidenav>
+  </mat-sidenav>
+  <mat-sidenav-content>
+    <mat-toolbar color="primary" class="toolbar">
+      <button mat-icon-button (click)="toggleSidenav()">
+        <mat-icon>menu</mat-icon>
+      </button>
+      <span class="spacer"></span>
+      <button mat-button (click)="selectBackend('local')" [disabled]="currentUrl === LOCAL_IIS">Localhost IIS</button>
+      <button mat-button (click)="selectBackend('aws')" [disabled]="currentUrl === AWS_URL">Remote sales.raphp.net</button>
+    </mat-toolbar>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/src/app/layout/toolbar/toolbar.component.spec.ts
+++ b/src/app/layout/toolbar/toolbar.component.spec.ts
@@ -20,4 +20,35 @@ describe('ToolbarComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should display menu button', () => {
+    const menuBtn = fixture.nativeElement.querySelector('button[mat-icon-button]');
+    expect(menuBtn).toBeTruthy();
+  });
+
+  it('should disable buttons based on current url', () => {
+    component.currentUrl = component.LOCAL_IIS;
+    fixture.detectChanges();
+    const buttons: HTMLButtonElement[] = fixture.nativeElement.querySelectorAll('button[mat-button]');
+    const localBtn = buttons[0];
+    const awsBtn = buttons[1];
+    expect(localBtn.disabled).toBeTrue();
+    expect(awsBtn.disabled).toBeFalse();
+
+    component.currentUrl = component.AWS_URL;
+    fixture.detectChanges();
+    expect(localBtn.disabled).toBeFalse();
+    expect(awsBtn.disabled).toBeTrue();
+  });
+
+  it('should invoke selectBackend on button click', () => {
+    spyOn(component, 'selectBackend');
+    const buttons: HTMLButtonElement[] = fixture.nativeElement.querySelectorAll('button[mat-button]');
+    const localBtn = buttons[0];
+    const awsBtn = buttons[1];
+    localBtn.click();
+    awsBtn.click();
+    expect(component.selectBackend).toHaveBeenCalledWith('local');
+    expect(component.selectBackend).toHaveBeenCalledWith('aws');
+  });
 });

--- a/src/app/layout/toolbar/toolbar.component.ts
+++ b/src/app/layout/toolbar/toolbar.component.ts
@@ -1,13 +1,16 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSidenavModule, MatSidenav } from '@angular/material/sidenav';
 import { BackendConfigService } from '../../services/backend-config.service';
+import { SidenavComponent } from '../sidenav/sidenav.component';
 
 @Component({
   selector: 'app-toolbar',
   standalone: true,
-  imports: [CommonModule, MatToolbarModule, MatButtonModule],
+  imports: [CommonModule, MatToolbarModule, MatButtonModule, MatIconModule, MatSidenavModule, SidenavComponent],
   templateUrl: './toolbar.component.html',
   styleUrl: './toolbar.component.css'
 })
@@ -16,7 +19,14 @@ export class ToolbarComponent {
   readonly AWS_URL = 'https://sales.raphp.net/GetCartResponse';
   currentUrl = this.backendConfig.baseUrl;
 
+  @ViewChild(MatSidenav)
+  sidenav?: MatSidenav;
+
   constructor(private backendConfig: BackendConfigService) {}
+
+  toggleSidenav(): void {
+    this.sidenav?.toggle();
+  }
 
   selectBackend(target: 'local' | 'aws'): void {
     this.currentUrl = target === 'local' ? this.LOCAL_IIS : this.AWS_URL;


### PR DESCRIPTION
## Summary
- add Material sidenav and icon modules to toolbar
- implement a menu button that toggles the sidenav
- keep backend selection buttons and disable them when selected
- expand toolbar tests for menu button and disable logic

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false --progress=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f710fa25c8321bce784045471beac