### PR TITLE
Fix backend base url usage

### DIFF
--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -2,17 +2,21 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { environment } from '../../environments/environment';
+import { BackendConfigService } from './backend-config.service';
 import { CartRequest } from '../entities/DTOs/cart/requests/cart-request.dto';
 import { CartResponse } from '../entities/DTOs/cart/responses/cart-response.dto';
 
 @Injectable({ providedIn: 'root' })
 export class CartService {
-  constructor(private http: HttpClient) {}
+  constructor(
+    private http: HttpClient,
+    private backendConfig: BackendConfigService
+  ) {}
 
   getCartResponse(request: CartRequest): Observable<CartResponse> {
+    const url = `${this.backendConfig.baseUrl}/GetCartResponse`;
     return this.http
-      .post<CartResponse>(`${environment.apiUrl}/GetCartResponse`, request)
+      .post<CartResponse>(url, request)
       .pipe(
         catchError((error: HttpErrorResponse) =>
           throwError(() => error.error ?? error)


### PR DESCRIPTION
## Summary
- use `BackendConfigService` in `CartService` so the selected backend URL is used

## Testing
- `npm test --silent` *(fails: Chrome cannot start as root)*

------
https://chatgpt.com/codex/tasks/task_e_68608d86f19c8321b0cdd039cedc1513