### PR TITLE
Fix base URL used by toolbar

### DIFF
--- a/src/app/layout/toolbar/toolbar.component.html
+++ b/src/app/layout/toolbar/toolbar.component.html
@@ -8,8 +8,8 @@
         <mat-icon>menu</mat-icon>
       </button>
       <span class="spacer"></span>
-      <button mat-button (click)="selectBackend('local')" [disabled]="currentUrl === localUrl">Localhost IIS</button>
-      <button mat-button (click)="selectBackend('aws')" [disabled]="currentUrl === awsUrl">Remote sales.raphp.net</button>
+      <button mat-button (click)="selectBackend('local')" [disabled]="currentUrl === localBaseUrl">Localhost IIS</button>
+      <button mat-button (click)="selectBackend('aws')" [disabled]="currentUrl === awsBaseUrl">Remote sales.raphp.net</button>
     </mat-toolbar>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/layout/toolbar/toolbar.component.spec.ts
+++ b/src/app/layout/toolbar/toolbar.component.spec.ts
@@ -23,20 +23,16 @@ describe('ToolbarComponent', () => {
   });
 
   it('should read endpoint values from environment', () => {
-    expect(component.awsUrl).toBe(
-      `${environment.endpoints.aws}/GetCartResponse`
-    );
-    expect(component.localUrl).toBe(
-      `${environment.endpoints.local}/GetCartResponse`
-    );
+    expect(component.awsBaseUrl).toBe(environment.endpoints.aws);
+    expect(component.localBaseUrl).toBe(environment.endpoints.local);
   });
 
   it('should update base url when selecting backend', () => {
     const service = TestBed.inject(BackendConfigService);
     spyOn(service, 'setBaseUrl').and.callThrough();
     component.selectBackend('local');
-    expect(service.setBaseUrl).toHaveBeenCalledWith(component.localUrl);
-    expect(component.currentUrl).toBe(component.localUrl);
+    expect(service.setBaseUrl).toHaveBeenCalledWith(component.localBaseUrl);
+    expect(component.currentUrl).toBe(component.localBaseUrl);
   });
 
   it('should display menu button', () => {
@@ -47,7 +43,7 @@ describe('ToolbarComponent', () => {
   });
 
   it('should disable buttons based on current url', () => {
-    component.currentUrl = component.localUrl;
+    component.currentUrl = component.localBaseUrl;
     fixture.detectChanges();
     const buttons: HTMLButtonElement[] =
       fixture.nativeElement.querySelectorAll('button[mat-button]');
@@ -56,7 +52,7 @@ describe('ToolbarComponent', () => {
     expect(localBtn.disabled).toBeTrue();
     expect(awsBtn.disabled).toBeFalse();
 
-    component.currentUrl = component.awsUrl;
+    component.currentUrl = component.awsBaseUrl;
     fixture.detectChanges();
     expect(localBtn.disabled).toBeFalse();
     expect(awsBtn.disabled).toBeTrue();

--- a/src/app/layout/toolbar/toolbar.component.ts
+++ b/src/app/layout/toolbar/toolbar.component.ts
@@ -16,8 +16,8 @@ import { SidenavComponent } from '../sidenav/sidenav.component';
   styleUrl: './toolbar.component.css'
 })
 export class ToolbarComponent {
-  readonly localUrl = `${environment.endpoints.local}/GetCartResponse`;
-  readonly awsUrl = `${environment.endpoints.aws}/GetCartResponse`;
+  readonly localBaseUrl = environment.endpoints.local;
+  readonly awsBaseUrl = environment.endpoints.aws;
   currentUrl = this.backendConfig.baseUrl;
 
   @ViewChild(MatSidenav)
@@ -30,7 +30,8 @@ export class ToolbarComponent {
   }
 
   selectBackend(target: 'local' | 'aws'): void {
-    this.currentUrl = target === 'local' ? this.localUrl : this.awsUrl;
+    this.currentUrl =
+      target === 'local' ? this.localBaseUrl : this.awsBaseUrl;
     this.backendConfig.setBaseUrl(this.currentUrl);
   }
 }


### PR DESCRIPTION
## Summary
- don't append `GetCartResponse` to backend URLs in the toolbar
- update toolbar tests for new `localBaseUrl` and `awsBaseUrl` API

## Testing
- `npm test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cb4f345c83219c685cc83df5478e